### PR TITLE
Add version constraint for Kilosort4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -28,6 +28,10 @@ requirements:
     - python-neo >=0.14.0
     - probeinterface >=0.2.23
     - packaging
+  run_constrained:
+    # As of 0.101.1, the minimum supported version of Kilosort4 is 4.0.16:
+    # https://github.com/SpikeInterface/spikeinterface/pull/3339
+    - kilosort >=4.0.16
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - python-neo >=0.14.0
     - probeinterface >=0.2.23
     - packaging
+    - numcodecs <0.16.0
   run_constrained:
     # As of 0.101.1, the minimum supported version of Kilosort4 is 4.0.16:
     # https://github.com/SpikeInterface/spikeinterface/pull/3339


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
SpikeInterface now only supports the latest version of Kilosort 4 (SpikeInterface/spikeinterface#3316). For 0.101.1, that's 4.0.16 (SpikeInterface/spikeinterface#3339).

I'm not sure how to test this without a conda package for Kilosort.